### PR TITLE
Change nlohmann_json to nlohmann-json-dev

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -52,12 +52,11 @@ RUN python3 -m venv --system-site-packages $VIRTUAL_ENV \
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Install all ROS dependencies
-RUN vcs import src < src/$PROJECT_NAME/ros2.repos
 WORKDIR $USER_WORKSPACE
 RUN sudo apt-get -q update \
     && sudo apt-get -q -y upgrade \
     && rosdep update \
-    && rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} --skip-keys nlohmann_json \
+    && rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} \
     && sudo apt-get autoremove -y \
     && sudo apt-get clean -y \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -52,12 +52,11 @@ RUN python3 -m venv --system-site-packages $VIRTUAL_ENV \
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Install all ROS dependencies
-RUN vcs import src < src/$PROJECT_NAME/ros2.repos
 WORKDIR $USER_WORKSPACE
 RUN sudo apt-get -q update \
     && sudo apt-get -q -y upgrade \
     && rosdep update \
-    && rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} --skip-keys nlohmann_json \
+    && rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} \
     && sudo apt-get autoremove -y \
     && sudo apt-get clean -y \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,5 @@
 *
 
 # Except the following
-!ros2.repos
 !waterlinked_dvl_driver
 !libwaterlinked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,5 @@ jobs:
           ROS_DISTRO: ${{ matrix.env.ROS_DISTRO }}
           CXXFLAGS: -Wall -Wextra -Wpedantic
           CLANG_TIDY: true
-          UPSTREAM_WORKSPACE: ros2.repos
           AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
           AFTER_SETUP_DOWNSTREAM_WORKSPACE: vcs pull $BASEDIR/downstream_ws/src
-          ROSDEP_SKIP_KEYS: nlohmann_json

--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ of your ROS 2 workspace
 git clone git@github.com:waterlinked/waterlinked_dvl.git
 ```
 
-Then install the project dependencies using vcstool and rosdep
+Then install the project dependencies using rosdep
 
 ```bash
-vcs import src < src/waterlinked_dvl/ros2.repos && \
-rosdep install --from paths src -y --ignore-src --skip-keys nlohmann_json
+rosdep install --from paths src -y --ignore-src
 ```
 
 Finally, build the workspace using colcon

--- a/libwaterlinked/package.xml
+++ b/libwaterlinked/package.xml
@@ -18,7 +18,7 @@
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <depend>eigen</depend>
-  <depend>nlohmann_json</depend>
+  <depend>nlohmann-json-dev</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>

--- a/ros2.repos
+++ b/ros2.repos
@@ -1,6 +1,0 @@
-repositories:
-
-  json:
-    type: git
-    url: https://github.com/nlohmann/json
-    version: master


### PR DESCRIPTION
This allows the nlohmann json library dependency to be installed with rosdep, and the ros2.repos file can be deleted.

## Changes Made

Renamed the `nlohmann_json` rosdep dependency in libwaterlinked to `nlohmann-json-dev` (which rosdep can resolve and install). This way, downstream users of this library don't need to use `--skip-keys nlohmann_json` on every build.