### PR TITLE
add support for water tracking velocity updates

### DIFF
--- a/libwaterlinked/include/libwaterlinked/protocol.hpp
+++ b/libwaterlinked/include/libwaterlinked/protocol.hpp
@@ -87,6 +87,9 @@ struct VelocityReport
   /// are reserved for future use.
   std::uint8_t status;
 
+  /// Type of report ("velocity" or "water_tracking").
+  std::string type;
+
   /// Timestamp of the surface reflection, aka 'center of ping' (Unix timestamp in microseconds).
   std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds> time_of_validity;
 

--- a/libwaterlinked/include/libwaterlinked/protocol.hpp
+++ b/libwaterlinked/include/libwaterlinked/protocol.hpp
@@ -87,7 +87,7 @@ struct VelocityReport
   /// are reserved for future use.
   std::uint8_t status;
 
-  /// Type of report ("velocity" or "water_tracking").
+  /// Type of report ("velocity" or "velocity_water").
   std::string type;
 
   /// Timestamp of the surface reflection, aka 'center of ping' (Unix timestamp in microseconds).

--- a/libwaterlinked/src/client.cpp
+++ b/libwaterlinked/src/client.cpp
@@ -276,7 +276,8 @@ auto WaterLinkedClient::process_json_object(const nlohmann::json & json_object) 
 {
   // There are only three types of messages sent by the DVL: velocity reports, dead reckoning reports, and command
   // responses.
-  if (json_object.at("type") == "velocity") {
+  if (json_object.at("type") == "velocity" || json_object.at("type") == "velocity_water") {
+    //We handle both velocity and velocity_water reports in the callback function
     const auto report = json_object.get<VelocityReport>();
     for (const auto & callback : velocity_report_callbacks_) {
       callback(report);

--- a/libwaterlinked/src/client.cpp
+++ b/libwaterlinked/src/client.cpp
@@ -277,7 +277,7 @@ auto WaterLinkedClient::process_json_object(const nlohmann::json & json_object) 
   // There are only three types of messages sent by the DVL: velocity reports, dead reckoning reports, and command
   // responses.
   if (json_object.at("type") == "velocity" || json_object.at("type") == "velocity_water") {
-    //We handle both velocity and velocity_water reports in the callback function
+    // We handle both velocity and velocity_water reports in the callback function
     const auto report = json_object.get<VelocityReport>();
     for (const auto & callback : velocity_report_callbacks_) {
       callback(report);

--- a/libwaterlinked/src/protocol.cpp
+++ b/libwaterlinked/src/protocol.cpp
@@ -88,9 +88,12 @@ auto from_json(const nlohmann::json & j, VelocityReport & r) -> void
   j.at("vy").get_to(r.vy);
   j.at("vz").get_to(r.vz);
   j.at("fom").get_to(r.fom);
-  j.at("altitude").get_to(r.altitude);
+  if (j.contains("altitude")) {
+    j.at("altitude").get_to(r.altitude);  //Not available if type is "velocity_water"
+  }
   j.at("velocity_valid").get_to(r.velocity_valid);
   j.at("status").get_to(r.status);
+  j.at("type").get_to(r.type);
   j.at("time_of_validity").get_to(r.time_of_validity);
   j.at("time_of_transmission").get_to(r.time_of_transmission);
   j.at("covariance").get_to(r.covariance);

--- a/libwaterlinked/src/protocol.cpp
+++ b/libwaterlinked/src/protocol.cpp
@@ -88,6 +88,7 @@ auto from_json(const nlohmann::json & j, VelocityReport & r) -> void
   j.at("vy").get_to(r.vy);
   j.at("vz").get_to(r.vz);
   j.at("fom").get_to(r.fom);
+  r.altitude = std::numeric_limits<double>::quiet_NaN();
   if (j.contains("altitude")) {
     j.at("altitude").get_to(r.altitude);  // Not available if type is "velocity_water"
   }

--- a/libwaterlinked/src/protocol.cpp
+++ b/libwaterlinked/src/protocol.cpp
@@ -89,7 +89,7 @@ auto from_json(const nlohmann::json & j, VelocityReport & r) -> void
   j.at("vz").get_to(r.vz);
   j.at("fom").get_to(r.fom);
   if (j.contains("altitude")) {
-    j.at("altitude").get_to(r.altitude);  //Not available if type is "velocity_water"
+    j.at("altitude").get_to(r.altitude);  // Not available if type is "velocity_water"
   }
   j.at("velocity_valid").get_to(r.velocity_valid);
   j.at("status").get_to(r.status);

--- a/libwaterlinked/test/test_json.cpp
+++ b/libwaterlinked/test/test_json.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include <Eigen/Dense>
+#include <cmath>
 #include <chrono>
 #include <nlohmann/json.hpp>
 
@@ -258,6 +259,129 @@ TEST(JsonParsing, ParseVelocityReport)
   EXPECT_DOUBLE_EQ(response.transducers[3].distance, 0.5472000241279602);
   EXPECT_DOUBLE_EQ(response.transducers[3].rssi, -28.006759643554688);
   EXPECT_DOUBLE_EQ(response.transducers[3].nsd, -88.32147216796875);
+  EXPECT_TRUE(response.transducers[3].beam_valid);
+}
+
+
+TEST(JsonParsing, ParseVelocityWaterReport)
+{
+  const std::string json_string = R"(
+  {
+    "time": 486.6678771972656,
+    "vx": -0.005870406981557608,
+    "vy": -0.005043691955506802,
+    "vz": 0.0002322260697837919,
+    "fom": 0.002009979449212551,
+    "covariance": [
+      [
+        0.0000025099461709032767,
+        0.0000013035447636866593,
+        -3.271562576401266E-8
+      ],
+      [
+        0.0000013035447636866593,
+        0.000002912906211349764,
+        2.8023941922583617E-7
+      ],
+      [
+        -3.271562576401266E-8,
+        2.8023941922583617E-7,
+        1.9223701031023666E-7
+      ]
+    ],
+    "transducers": [
+      {
+        "id": 0,
+        "velocity": -0.0004092144372407347,
+        "distance": -1,
+        "rssi": -21.295808792114258,
+        "nsd": -43.26792907714844,
+        "beam_valid": true
+      },
+      {
+        "id": 1,
+        "velocity": 0.0004326871130615473,
+        "distance": -1,
+        "rssi": -24.12013816833496,
+        "nsd": -45.38116455078125,
+        "beam_valid": true
+      },
+      {
+        "id": 2,
+        "velocity": -0.0006910116062499583,
+        "distance": -1,
+        "rssi": -22.13231086730957,
+        "nsd": -44.35983657836914,
+        "beam_valid": true
+      },
+      {
+        "id": 3,
+        "velocity": 0.004602331202477217,
+        "distance": -1,
+        "rssi": -28.323562622070312,
+        "nsd": -39.62949752807617,
+        "beam_valid": true
+      }
+    ],
+    "velocity_valid": true,
+    "status": 0,
+    "format": "json_v3.3",
+    "type": "velocity_water",
+    "time_of_validity": 1786001128432658,
+    "time_of_transmission": 1786001129279697
+  }
+  )";
+
+  const auto obj = nlohmann::json::parse(json_string);
+  const auto response = obj.get<VelocityReport>();
+
+  EXPECT_EQ(response.time.count(), 486);
+  EXPECT_DOUBLE_EQ(response.vx, -0.005870406981557608);
+  EXPECT_DOUBLE_EQ(response.vy, -0.005043691955506802);
+  EXPECT_DOUBLE_EQ(response.vz, 0.0002322260697837919);
+  EXPECT_DOUBLE_EQ(response.fom, 0.002009979449212551);
+  EXPECT_TRUE(std::isnan(response.altitude));
+  EXPECT_EQ(response.transducers.size(), 4);
+  EXPECT_TRUE(response.velocity_valid);
+  EXPECT_EQ(response.status, 0);
+  EXPECT_EQ(response.type, "velocity_water");
+  EXPECT_EQ(response.time_of_validity.time_since_epoch().count(), 1786001128432658);
+  EXPECT_EQ(response.time_of_transmission.time_since_epoch().count(), 1786001129279697);
+
+  // Test the covariance matrix
+  Eigen::Matrix3d expected_covariance;
+  expected_covariance << 0.0000025099461709032767, 0.0000013035447636866593, -3.271562576401266E-8,
+    0.0000013035447636866593, 0.000002912906211349764, 2.8023941922583617E-7, -3.271562576401266E-8,
+    2.8023941922583617E-7, 1.9223701031023666E-7;
+  EXPECT_EQ(response.covariance, expected_covariance);
+
+  // Test the transducer reports
+  EXPECT_EQ(response.transducers[0].id, 0);
+  EXPECT_DOUBLE_EQ(response.transducers[0].velocity, -0.0004092144372407347);
+  EXPECT_DOUBLE_EQ(response.transducers[0].distance, -1.0);
+  EXPECT_DOUBLE_EQ(response.transducers[0].rssi, -21.295808792114258);
+  EXPECT_DOUBLE_EQ(response.transducers[0].nsd, -43.26792907714844);
+  EXPECT_TRUE(response.transducers[0].beam_valid);
+
+  EXPECT_EQ(response.transducers[1].id, 1);
+  EXPECT_DOUBLE_EQ(response.transducers[1].velocity, 0.0004326871130615473);
+  EXPECT_DOUBLE_EQ(response.transducers[1].distance, -1.0);
+  EXPECT_DOUBLE_EQ(response.transducers[1].rssi, -24.12013816833496);
+  EXPECT_DOUBLE_EQ(response.transducers[1].nsd, -45.38116455078125);
+  EXPECT_TRUE(response.transducers[1].beam_valid);
+
+  EXPECT_EQ(response.transducers[2].id, 2);
+  EXPECT_DOUBLE_EQ(response.transducers[2].velocity, -0.0006910116062499583);
+  EXPECT_DOUBLE_EQ(response.transducers[2].distance, -1.0);
+  EXPECT_DOUBLE_EQ(response.transducers[2].rssi, -22.13231086730957);
+  EXPECT_DOUBLE_EQ(response.transducers[2].nsd, -44.35983657836914);
+  EXPECT_TRUE(response.transducers[2].beam_valid);
+
+  EXPECT_EQ(response.transducers[3].id, 3);
+  EXPECT_DOUBLE_EQ(response.transducers[3].velocity, 0.004602331202477217);
+  EXPECT_DOUBLE_EQ(response.transducers[3].distance, -1.0);
+  EXPECT_DOUBLE_EQ(response.transducers[3].rssi, -28.323562622070312);
+  EXPECT_DOUBLE_EQ(response.transducers[3].nsd, -39.62949752807617);
   EXPECT_TRUE(response.transducers[3].beam_valid);
 }
 

--- a/libwaterlinked/test/test_json.cpp
+++ b/libwaterlinked/test/test_json.cpp
@@ -21,8 +21,8 @@
 #include <gtest/gtest.h>
 
 #include <Eigen/Dense>
-#include <cmath>
 #include <chrono>
+#include <cmath>
 #include <nlohmann/json.hpp>
 
 #include "libwaterlinked/protocol.hpp"
@@ -261,7 +261,6 @@ TEST(JsonParsing, ParseVelocityReport)
   EXPECT_DOUBLE_EQ(response.transducers[3].nsd, -88.32147216796875);
   EXPECT_TRUE(response.transducers[3].beam_valid);
 }
-
 
 TEST(JsonParsing, ParseVelocityWaterReport)
 {

--- a/waterlinked_dvl_driver/include/waterlinked_dvl_driver/waterlinked_dvl_driver.hpp
+++ b/waterlinked_dvl_driver/include/waterlinked_dvl_driver/waterlinked_dvl_driver.hpp
@@ -60,6 +60,7 @@ private:
   nav_msgs::msg::Odometry odom_msg_;
 
   std::shared_ptr<rclcpp::Publisher<marine_acoustic_msgs::msg::Dvl>> dvl_pub_;
+  std::shared_ptr<rclcpp::Publisher<marine_acoustic_msgs::msg::Dvl>> dvl_water_pub_;
   std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>> dead_reckoning_pub_;
   std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::Odometry>> odom_pub_;
 

--- a/waterlinked_dvl_driver/src/waterlinked_dvl_driver.cpp
+++ b/waterlinked_dvl_driver/src/waterlinked_dvl_driver.cpp
@@ -144,9 +144,10 @@ auto WaterLinkedDvlDriver::on_configure(const rclcpp_lifecycle::State & /*previo
     dvl_msg_.header.stamp = rclcpp::Time(t.time_since_epoch().count());
     if (report.type == "velocity_water") {
       dvl_msg_.velocity_mode = marine_acoustic_msgs::msg::Dvl::DVL_MODE_WATER;
+      dvl_msg_.altitude = NAN;  // We don't have altitude for water tracking reports, set to NAN to indicate that it is unknown
     } else {
       dvl_msg_.velocity_mode = marine_acoustic_msgs::msg::Dvl::DVL_MODE_BOTTOM;
-      dvl_msg_.altitude = report.altitude;  // We only have altitude for bottom lock reports, not water lock reports
+      dvl_msg_.altitude = report.altitude;
     }
     dvl_msg_.velocity.x = report.vx;
     dvl_msg_.velocity.y = report.vy;
@@ -155,6 +156,7 @@ auto WaterLinkedDvlDriver::on_configure(const rclcpp_lifecycle::State & /*previo
     dvl_msg_.beam_velocities_valid = report.velocity_valid;
     dvl_msg_.course_gnd = std::atan2(report.vy, report.vx);
     dvl_msg_.speed_gnd = std::sqrt((report.vx * report.vx) + (report.vy * report.vy));
+    dvl_msg_.sound_speed = params_.speed_of_sound;  //Note - if sound of speed changes outside of the driver we don't catch it
 
     for (std::size_t i = 0; i < 3; ++i) {
       for (std::size_t j = 0; j < 3; ++j) {

--- a/waterlinked_dvl_driver/src/waterlinked_dvl_driver.cpp
+++ b/waterlinked_dvl_driver/src/waterlinked_dvl_driver.cpp
@@ -134,7 +134,8 @@ auto WaterLinkedDvlDriver::on_configure(const rclcpp_lifecycle::State & /*previo
   dvl_msg_.beam_unit_vec[3].z = 0.38268343236508984;
 
   dvl_pub_ = create_publisher<marine_acoustic_msgs::msg::Dvl>("~/velocity_report", rclcpp::SystemDefaultsQoS());
-  dvl_water_pub_ = create_publisher<marine_acoustic_msgs::msg::Dvl>("~/velocity_water_report", rclcpp::SystemDefaultsQoS());
+  dvl_water_pub_ =
+    create_publisher<marine_acoustic_msgs::msg::Dvl>("~/velocity_water_report", rclcpp::SystemDefaultsQoS());
   odom_pub_ = create_publisher<nav_msgs::msg::Odometry>("~/odom", rclcpp::SystemDefaultsQoS());
   dead_reckoning_pub_ = create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "~/dead_reckoning_report", rclcpp::SystemDefaultsQoS());
@@ -144,7 +145,7 @@ auto WaterLinkedDvlDriver::on_configure(const rclcpp_lifecycle::State & /*previo
     dvl_msg_.header.stamp = rclcpp::Time(t.time_since_epoch().count());
     if (report.type == "velocity_water") {
       dvl_msg_.velocity_mode = marine_acoustic_msgs::msg::Dvl::DVL_MODE_WATER;
-      dvl_msg_.altitude = NAN;  // We don't have altitude for water tracking reports, set to NAN to indicate that it is unknown
+      dvl_msg_.altitude = NAN;  // Set to NAN to indicate that it is unknown
     } else {
       dvl_msg_.velocity_mode = marine_acoustic_msgs::msg::Dvl::DVL_MODE_BOTTOM;
       dvl_msg_.altitude = report.altitude;
@@ -156,7 +157,7 @@ auto WaterLinkedDvlDriver::on_configure(const rclcpp_lifecycle::State & /*previo
     dvl_msg_.beam_velocities_valid = report.velocity_valid;
     dvl_msg_.course_gnd = std::atan2(report.vy, report.vx);
     dvl_msg_.speed_gnd = std::sqrt((report.vx * report.vx) + (report.vy * report.vy));
-    dvl_msg_.sound_speed = params_.speed_of_sound;  //Note - if sound of speed changes outside of the driver we don't catch it
+    dvl_msg_.sound_speed = params_.speed_of_sound;  // OBS Can change outside of driver without being caught
 
     for (std::size_t i = 0; i < 3; ++i) {
       for (std::size_t j = 0; j < 3; ++j) {
@@ -171,8 +172,9 @@ auto WaterLinkedDvlDriver::on_configure(const rclcpp_lifecycle::State & /*previo
       dvl_msg_.range[i] = report.transducers[i].distance;
       dvl_msg_.num_good_beams += report.transducers[i].beam_valid ? 1 : 0;
     }
-    //Publish in separate topics - debatable if this is the best approach
-    //See : https://github.com/apl-ocean-engineering/marine_msgs/tree/main/marine_acoustic_msgs#dvl-specific-design-decisions
+    // Publish in separate topics - debatable if this is the best approach
+    // See :
+    // https://github.com/apl-ocean-engineering/marine_msgs/tree/main/marine_acoustic_msgs#dvl-specific-design-decisions
     if (report.type == "velocity_water") {
       dvl_water_pub_->publish(dvl_msg_);  // NOLINT(portability-template-virtual-member-function)
     } else {

--- a/waterlinked_dvl_driver/src/waterlinked_dvl_driver.cpp
+++ b/waterlinked_dvl_driver/src/waterlinked_dvl_driver.cpp
@@ -101,7 +101,11 @@ auto WaterLinkedDvlDriver::on_configure(const rclcpp_lifecycle::State & /*previo
   dead_reckoning_msg_.header.frame_id = params_.frame_id;
   odom_msg_.header.frame_id = params_.frame_id;
 
-  dvl_msg_.velocity_mode = marine_acoustic_msgs::msg::Dvl::DVL_MODE_BOTTOM;
+  if (params_.range_mode == "wt") {
+    dvl_msg_.velocity_mode = marine_acoustic_msgs::msg::Dvl::DVL_MODE_WATER;
+  } else {
+    dvl_msg_.velocity_mode = marine_acoustic_msgs::msg::Dvl::DVL_MODE_BOTTOM;
+  }
   dvl_msg_.dvl_type = marine_acoustic_msgs::msg::Dvl::DVL_TYPE_PISTON;  // 4-beam convex Janus array
 
   // The following has been retrieved from:
@@ -130,6 +134,7 @@ auto WaterLinkedDvlDriver::on_configure(const rclcpp_lifecycle::State & /*previo
   dvl_msg_.beam_unit_vec[3].z = 0.38268343236508984;
 
   dvl_pub_ = create_publisher<marine_acoustic_msgs::msg::Dvl>("~/velocity_report", rclcpp::SystemDefaultsQoS());
+  dvl_water_pub_ = create_publisher<marine_acoustic_msgs::msg::Dvl>("~/velocity_water_report", rclcpp::SystemDefaultsQoS());
   odom_pub_ = create_publisher<nav_msgs::msg::Odometry>("~/odom", rclcpp::SystemDefaultsQoS());
   dead_reckoning_pub_ = create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "~/dead_reckoning_report", rclcpp::SystemDefaultsQoS());
@@ -137,7 +142,12 @@ auto WaterLinkedDvlDriver::on_configure(const rclcpp_lifecycle::State & /*previo
   client_->register_callback([this](const VelocityReport & report) -> void {
     const auto t = std::chrono::time_point_cast<std::chrono::nanoseconds>(report.time_of_validity);
     dvl_msg_.header.stamp = rclcpp::Time(t.time_since_epoch().count());
-    dvl_msg_.altitude = report.altitude;
+    if (report.type == "velocity_water") {
+      dvl_msg_.velocity_mode = marine_acoustic_msgs::msg::Dvl::DVL_MODE_WATER;
+    } else {
+      dvl_msg_.velocity_mode = marine_acoustic_msgs::msg::Dvl::DVL_MODE_BOTTOM;
+      dvl_msg_.altitude = report.altitude;  // We only have altitude for bottom lock reports, not water lock reports
+    }
     dvl_msg_.velocity.x = report.vx;
     dvl_msg_.velocity.y = report.vy;
     dvl_msg_.velocity.z = report.vz;
@@ -159,8 +169,13 @@ auto WaterLinkedDvlDriver::on_configure(const rclcpp_lifecycle::State & /*previo
       dvl_msg_.range[i] = report.transducers[i].distance;
       dvl_msg_.num_good_beams += report.transducers[i].beam_valid ? 1 : 0;
     }
-
-    dvl_pub_->publish(dvl_msg_);  // NOLINT(portability-template-virtual-member-function)
+    //Publish in separate topics - debatable if this is the best approach
+    //See : https://github.com/apl-ocean-engineering/marine_msgs/tree/main/marine_acoustic_msgs#dvl-specific-design-decisions
+    if (report.type == "velocity_water") {
+      dvl_water_pub_->publish(dvl_msg_);  // NOLINT(portability-template-virtual-member-function)
+    } else {
+      dvl_pub_->publish(dvl_msg_);  // NOLINT(portability-template-virtual-member-function)
+    }
   });
 
   // much of the following code could be moved into the above callback, but we separate it to improve readability


### PR DESCRIPTION
## Changes Made

Adds support for water tracking velocity updates, introduced in v2.7.x of DVL firmware.
Discovered that sound_speed in the velocity_report was not set, so set it to parametrized value - NB this does not catch changes in speed of sound set outside the driver.

## Testing

Start driver with `ros2 launch waterlinked_dvl_driver dvl.launch.py`
Observe that following topics are available:

> $ ros2 topic list
>/parameter_events
>/rosout
>/waterlinked_dvl_driver/dead_reckoning_report
>/waterlinked_dvl_driver/odom
>/waterlinked_dvl_driver/transition_event
>/waterlinked_dvl_driver/velocity_report
>/waterlinked_dvl_driver/velocity_water_report

Observed that we get velocity reports on "velocity_report" or "velocity_water_report" topics, depending on whether bottom or water tracking. Also observed that "velocity_mode" is set to 1 for bottom tracking, 2 for water tracking, as defined in [https://github.com/apl-ocean-engineering/marine_msgs/blob/main/marine_acoustic_msgs/msg/Dvl.msg](url)
Altitude is set to NaN for the water tracking velocity report. Example:
<img width="412" height="1225" alt="image" src="https://github.com/user-attachments/assets/65f7044a-1e42-4a5c-bd9c-4eb7916ffd09" />