### PR TITLE
Fix blocking send while holding request mutex

### DIFF
--- a/libwaterlinked/CMakeLists.txt
+++ b/libwaterlinked/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 project(
     libwaterlinked
-    VERSION 0.0.1
+    VERSION 0.0.2
     LANGUAGES CXX
     DESCRIPTION "C++ library used to interact with the Water Linked DVL devices"
 )

--- a/libwaterlinked/include/libwaterlinked/client.hpp
+++ b/libwaterlinked/include/libwaterlinked/client.hpp
@@ -137,6 +137,7 @@ private:
 
   std::chrono::steady_clock::duration command_timeout_;
   std::unordered_map<std::string, std::deque<PendingRequest>> pending_requests_;
+  std::mutex send_mutex_;
   std::mutex request_mutex_;
 
   std::thread polling_thread_;

--- a/libwaterlinked/package.xml
+++ b/libwaterlinked/package.xml
@@ -3,10 +3,10 @@
 <package format="3">
 
   <name>libwaterlinked</name>
-  <version>0.0.1</version>
+  <version>0.0.2</version>
   <description>C++ library used to interact with Water Linked DVL devices</description>
 
-  <maintainer email="evanp922@gmail.com">Evan Palmer</maintainer>
+  <maintainer email="support@waterlinked.com">Water Linked</maintainer>
   <license>MIT</license>
 
   <url type="repository">https://github.com/waterlinked/waterlinked_dvl</url>

--- a/libwaterlinked/src/client.cpp
+++ b/libwaterlinked/src/client.cpp
@@ -429,7 +429,10 @@ auto WaterLinkedClient::poll_connection() -> void
   for (auto & [command, pending_responses] : pending_requests_) {
     while (!pending_responses.empty()) {
       pending_responses.front().response.set_value(
-        {command, false, "DVL connection closed while waiting for response to command: " + command, {}});
+        {.response_to = command,
+         .success = false,
+         .error_message = "DVL connection closed while waiting for response to command: " + command,
+         .result = {}});
       pending_responses.pop_front();
     }
   }

--- a/libwaterlinked/src/client.cpp
+++ b/libwaterlinked/src/client.cpp
@@ -210,8 +210,7 @@ auto WaterLinkedClient::send_command(const nlohmann::json & command) -> std::fut
     requests.emplace_back(std::move(response), std::chrono::steady_clock::now() + command_timeout_);
   }
 
-  if (send(socket_, command_str.c_str(), command_str.size(), 0) < 0) {
-    // If the send fails, we need to remove the pending request from the queue so that it doesn't hang forever
+  const auto remove_pending_request = [this, &command_name]() -> void {
     const std::scoped_lock request_lock(request_mutex_);
     auto requests = pending_requests_.find(command_name);
     if (requests != pending_requests_.end() && !requests->second.empty()) {
@@ -220,8 +219,26 @@ auto WaterLinkedClient::send_command(const nlohmann::json & command) -> std::fut
         pending_requests_.erase(requests);
       }
     }
+  };
 
-    throw std::runtime_error("Failed to send command to DVL");
+  std::size_t total_sent = 0;
+  while (total_sent < command_str.size()) {
+    const ssize_t n_sent = send(socket_, command_str.data() + total_sent, command_str.size() - total_sent, 0);
+    if (n_sent < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+
+      remove_pending_request();
+      throw std::runtime_error("Failed to send command to DVL");
+    }
+
+    if (n_sent == 0) {
+      remove_pending_request();
+      throw std::runtime_error("Failed to send full command to DVL");
+    }
+
+    total_sent += static_cast<std::size_t>(n_sent);
   }
 
   return future;

--- a/libwaterlinked/src/client.cpp
+++ b/libwaterlinked/src/client.cpp
@@ -202,12 +202,25 @@ auto WaterLinkedClient::send_command(const nlohmann::json & command) -> std::fut
   auto future = response.get_future();
 
   const std::string command_str{command.dump()};
-  std::lock_guard lock(request_mutex_);
-  auto & requests = pending_requests_[command_name];
-  requests.emplace_back(std::move(response), std::chrono::steady_clock::now() + command_timeout_);
+  const std::scoped_lock send_lock(send_mutex_);
+
+  {
+    const std::scoped_lock request_lock(request_mutex_);
+    auto & requests = pending_requests_[command_name];
+    requests.emplace_back(std::move(response), std::chrono::steady_clock::now() + command_timeout_);
+  }
 
   if (send(socket_, command_str.c_str(), command_str.size(), 0) < 0) {
-    requests.pop_back();
+    // If the send fails, we need to remove the pending request from the queue so that it doesn't hang forever
+    const std::scoped_lock request_lock(request_mutex_);
+    auto requests = pending_requests_.find(command_name);
+    if (requests != pending_requests_.end() && !requests->second.empty()) {
+      requests->second.pop_back();
+      if (requests->second.empty()) {
+        pending_requests_.erase(requests);
+      }
+    }
+
     throw std::runtime_error("Failed to send command to DVL");
   }
 
@@ -272,13 +285,13 @@ auto WaterLinkedClient::reset_dead_reckoning() -> std::future<CommandResponse>
 
 auto WaterLinkedClient::register_callback(std::function<void(const VelocityReport &)> && callback) -> void
 {
-  std::lock_guard lock(callback_mutex_);
+  const std::scoped_lock lock(callback_mutex_);
   velocity_report_callbacks_.emplace_back(std::move(callback));
 }
 
 auto WaterLinkedClient::register_callback(std::function<void(const DeadReckoningReport &)> && callback) -> void
 {
-  std::lock_guard lock(callback_mutex_);
+  const std::scoped_lock lock(callback_mutex_);
   dead_reckoning_report_callbacks_.emplace_back(std::move(callback));
 }
 
@@ -291,7 +304,7 @@ auto WaterLinkedClient::process_json_object(const nlohmann::json & json_object) 
     const auto report = json_object.get<VelocityReport>();
     std::vector<std::function<void(const VelocityReport &)>> callbacks;
     {
-      std::lock_guard lock(callback_mutex_);
+      const std::scoped_lock lock(callback_mutex_);
       callbacks = velocity_report_callbacks_;
     }
     for (const auto & callback : callbacks) {
@@ -301,7 +314,7 @@ auto WaterLinkedClient::process_json_object(const nlohmann::json & json_object) 
     const auto report = json_object.get<DeadReckoningReport>();
     std::vector<std::function<void(const DeadReckoningReport &)>> callbacks;
     {
-      std::lock_guard lock(callback_mutex_);
+      const std::scoped_lock lock(callback_mutex_);
       callbacks = dead_reckoning_report_callbacks_;
     }
     for (const auto & callback : callbacks) {
@@ -309,7 +322,7 @@ auto WaterLinkedClient::process_json_object(const nlohmann::json & json_object) 
     }
   } else if (json_object.at("type") == "response") {
     const auto response = json_object.get<CommandResponse>();
-    std::lock_guard lock(request_mutex_);
+    const std::scoped_lock lock(request_mutex_);
     const auto pending_request = pending_requests_.find(response.response_to);
     if (pending_request != pending_requests_.end() && !pending_request->second.empty()) {
       pending_request->second.front().response.set_value(response);
@@ -333,12 +346,15 @@ auto WaterLinkedClient::poll_connection() -> void
   while (running_.load()) {
     {
       const auto now = std::chrono::steady_clock::now();
-      std::lock_guard lock(request_mutex_);
+      const std::scoped_lock lock(request_mutex_);
       for (auto request = pending_requests_.begin(); request != pending_requests_.end();) {
         auto & pending_responses = request->second;
         while (!pending_responses.empty() && pending_responses.front().deadline <= now) {
           pending_responses.front().response.set_value(
-            {request->first, false, "Timed out waiting for response to DVL command: " + request->first, {}});
+            {.response_to = request->first,
+             .success = false,
+             .error_message = "Timed out waiting for response to DVL command: " + request->first,
+             .result = {}});
           pending_responses.pop_front();
         }
 
@@ -409,7 +425,7 @@ auto WaterLinkedClient::poll_connection() -> void
     n_bytes_to_read = max_bytes_to_read - buffer.size();
   }
 
-  std::lock_guard lock(request_mutex_);
+  const std::scoped_lock lock(request_mutex_);
   for (auto & [command, pending_responses] : pending_requests_) {
     while (!pending_responses.empty()) {
       pending_responses.front().response.set_value(


### PR DESCRIPTION
Move send() outside request_mutex_ while preserving command ordering with send_mutex_. Also apply clang-tidy modernize fixes in client.cpp.

## Changes Made

Changes to libwaterlinked client.cpp to resolve blocking issue.

## Associated Issues

Resolves issue discussed in https://github.com/waterlinked/waterlinked_dvl/pull/32

## Testing

Please provide a clear and concise description of the testing performed.
